### PR TITLE
Refactor `interfaces` to use composition over inheritance

### DIFF
--- a/src/matcher.cr
+++ b/src/matcher.cr
@@ -1,5 +1,5 @@
 module Spec2
-  abstract class Matcher
+  module Matcher
     abstract def match(actual)
     abstract def failure_message
     abstract def failure_message_when_negated

--- a/src/matchers/be.cr
+++ b/src/matchers/be.cr
@@ -1,7 +1,9 @@
 module Spec2
   module Matchers
-    class Be < Matcher
+    class Be
+      include Matcher
       getter expected, actual
+
       def initialize(@expected)
       end
 
@@ -27,8 +29,7 @@ module Spec2
     end
 
     class BeRecorder(T)
-      def initialize(@actual : T, @expectation)
-      end
+      def initialize(@actual : T, @expectation); end
 
       macro method_missing(name, args, block)
         ok = !!(@actual.{{name.id}}({{args.argify}}) {{block}})

--- a/src/matchers/be_a.cr
+++ b/src/matchers/be_a.cr
@@ -1,7 +1,9 @@
 module Spec2
   module Matchers
-    class BeA(T) < Matcher
+    class BeA(T)
+      include Matcher
       getter actual
+
       def match(@actual)
         actual.is_a?(T)
       end

--- a/src/matchers/bool.cr
+++ b/src/matchers/bool.cr
@@ -1,7 +1,9 @@
 module Spec2
   module Matchers
-    class BeTruthy < Matcher
+    class BeTruthy
+      include Matcher
       getter actual
+
       def match(@actual)
         !!actual
       end
@@ -19,8 +21,10 @@ module Spec2
       end
     end
 
-    class BeFalsey < Matcher
+    class BeFalsey
+      include Matcher
       getter actual
+
       def match(@actual)
         !actual
       end

--- a/src/matchers/close.cr
+++ b/src/matchers/close.cr
@@ -1,10 +1,11 @@
 module Spec2
   module Matchers
-    class Close < Matcher
+    class Close
+      include Matcher
       getter actual, expected, delta
       getter! actual_delta
-      def initialize(@expected, @delta)
-      end
+
+      def initialize(@expected, @delta); end
 
       def match(@actual)
         @actual_delta = (actual - expected).abs

--- a/src/matchers/eq.cr
+++ b/src/matchers/eq.cr
@@ -1,11 +1,11 @@
 module Spec2
   module Matchers
-    class Eq < Matcher
+    class Eq
+      include Matcher
       getter expected
       getter actual
 
-      def initialize(@expected)
-      end
+      def initialize(@expected); end
 
       def match(@actual)
         expected == actual

--- a/src/matchers/match.cr
+++ b/src/matchers/match.cr
@@ -1,9 +1,10 @@
 module Spec2
   module Matchers
-    class Match < Matcher
+    class Match
+      include Matcher
       getter expected, actual
-      def initialize(@expected)
-      end
+
+      def initialize(@expected); end
 
       def match(@actual)
         !!(actual =~ expected)

--- a/src/order.cr
+++ b/src/order.cr
@@ -1,5 +1,5 @@
 module Spec2
-  abstract class Order
+  module Order
     abstract def order(list)
   end
 end

--- a/src/orders/default.cr
+++ b/src/orders/default.cr
@@ -1,6 +1,8 @@
 module Spec2
   module Orders
-    class Default < Order
+    class Default
+      include Order
+
       def order(list)
         list
       end

--- a/src/orders/random.cr
+++ b/src/orders/random.cr
@@ -1,6 +1,8 @@
 module Spec2
   module Orders
-    class Random < Order
+    class Random
+      include Order
+
       def order(list)
         list.shuffle
       end

--- a/src/output.cr
+++ b/src/output.cr
@@ -1,5 +1,5 @@
 module Spec2
-  abstract class Output
+   module Output
     abstract def print(style, string)
 
     def print(string)

--- a/src/outputs/default.cr
+++ b/src/outputs/default.cr
@@ -1,6 +1,8 @@
 module Spec2
   module Outputs
-    class Default < Output
+    class Default
+      include Output
+
       COLORS = {
         success: :green,
         failure: :red,

--- a/src/outputs/nocolor.cr
+++ b/src/outputs/nocolor.cr
@@ -1,6 +1,8 @@
 module Spec2
   module Outputs
-    class Nocolor < Output
+    class Nocolor
+      include Output
+
       def print(style, string)
         STDOUT.print(string)
       end

--- a/src/reporter.cr
+++ b/src/reporter.cr
@@ -1,5 +1,5 @@
 module Spec2
-  abstract class Reporter
+  module Reporter
     abstract def configure_output(output)
     abstract def context_started(context)
     abstract def context_finished(context)

--- a/src/reporters/default.cr
+++ b/src/reporters/default.cr
@@ -1,6 +1,8 @@
 module Spec2
   module Reporters
-    class Default < Reporter
+    class Default
+      include Reporter
+
       getter! output
       def initialize
         @count = 0

--- a/src/reporters/doc.cr
+++ b/src/reporters/doc.cr
@@ -1,6 +1,8 @@
 module Spec2
   module Reporters
-    class Doc < Reporter
+    class Doc
+      include Reporter
+
       getter! output, nesting
       def initialize
         @count = 0

--- a/src/reporters/test.cr
+++ b/src/reporters/test.cr
@@ -2,11 +2,13 @@ module Spec2
   module Reporters
     struct TestEvent
       property event, example, exception
-      def initialize(@event, @example, @exception)
-      end
+
+      def initialize(@event, @example, @exception); end
     end
 
-    class Test < Reporter
+    class Test
+      include Reporter
+
       getter received
       def initialize
         @received = [] of TestEvent

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -1,5 +1,5 @@
 module Spec2
-  abstract class Runner
+  module Runner
     abstract def run_context(reporter, order, context)
     abstract def current_context
     abstract def failed?

--- a/src/runners/default.cr
+++ b/src/runners/default.cr
@@ -1,6 +1,8 @@
 module Spec2
   module Runners
-    class Default < Runner
+    class Default
+      include Runner
+
       getter current_context
 
       def failed?


### PR DESCRIPTION
For instance the `Reporter` class becomes a module that can be included in any class, without enforcing the class to inherit from the old abstract class.

Basically this implies that any class can act as a 'reporter', yet it
does not need actualy to inherits from it, if implements the necessary
interface.

Affected interfaces: Matcher, Order, Output, Reporter, Runner
