### PR TITLE
Add elapsed time support [#25]

### DIFF
--- a/src/reporter.cr
+++ b/src/reporter.cr
@@ -8,5 +8,20 @@ module Spec2
     abstract def example_failed(example, exception)
     abstract def example_errored(example, exception)
     abstract def report
+
+    private def elapsed_time
+      elapsed_time = Time.now - Spec2.started_at
+      total_seconds = elapsed_time.total_seconds
+
+      if total_seconds < 1
+        output.puts "Finished in #{elapsed_time.total_milliseconds.round(2)} milliseconds"
+      elsif total_seconds < 60
+        output.puts "Finished in #{total_seconds.round(2)} seconds"
+      else
+        minutes = elapsed_time.minutes
+        seconds = elapsed_time.seconds
+        output.puts "Finished in #{minutes}:#{seconds < 10 ? "0" : ""}#{seconds} minutes"
+      end
+    end
   end
 end

--- a/src/reporters/default.cr
+++ b/src/reporters/default.cr
@@ -48,6 +48,7 @@ module Spec2
         output.puts
         status = @errors.size > 0 ? :failure : :success
         output.puts status, "Examples: #{@count}, failures: #{@errors.size}"
+        output.puts elapsed_time
       end
     end
   end

--- a/src/reporters/doc.cr
+++ b/src/reporters/doc.cr
@@ -52,6 +52,7 @@ module Spec2
         output.puts
         status = @errors.size > 0 ? :failure : :success
         output.puts status, "Examples: #{@count}, failures: #{@errors.size}"
+        output.puts elapsed_time
       end
 
       private def indent

--- a/src/spec2.cr
+++ b/src/spec2.cr
@@ -23,9 +23,14 @@ module Spec2
   extend self
 
   @@high_runner = HighRunner.new(Context.instance)
+  @@started_at = Time.now
 
   def high_runner
     @@high_runner
+  end
+
+  def started_at
+    @@started_at
   end
 
   def configure_high_runner(@@high_runner)


### PR DESCRIPTION
Try to instanciate and store a `Time.now` as soon as possible
Use the started_at in order to calculate the elapsed time on the
abstract report

---

@waterlink I'm pretty sure that is not the `perfect` way of doing this, yet it is just a suggestion, I hope we can find the most adequate solution soon.

I haven't tested because I believe we would have to mock time, so I want to know first what you think about the solution.

---

fixes #25 
