### PR TITLE
Refactor and improve elapsed time logic

### DIFF
--- a/spec/elapsed_time_spec.cr
+++ b/spec/elapsed_time_spec.cr
@@ -1,0 +1,125 @@
+require "./spec_helper"
+require "../src/elapsed_time"
+
+module Spec2
+  Spec2.describe ElapsedTime do
+    let(:started_at) { Time.new(2014, 4, 21, 13, 27, 33, 57) }
+
+    describe "#to_s" do
+      context "when seconds < 1" do
+        it "returns in milliseconds" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 1.milliseconds,
+          ).to_s).to eq("1 milliseconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 50.milliseconds,
+          ).to_s).to eq("50 milliseconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 999.milliseconds,
+          ).to_s).to eq("999 milliseconds")
+        end
+
+        it "returns in milliseconds rounded to .2" do
+          expect(ElapsedTime.new(
+            started_at,
+            started_at + Time::Span.new(36 * 10000)
+          ).to_s).to eq("36 milliseconds")
+
+          expect(ElapsedTime.new(
+            started_at,
+            started_at + Time::Span.new(36.5 * 10000)
+          ).to_s).to eq("36.5 milliseconds")
+
+          expect(ElapsedTime.new(
+            started_at,
+            started_at + Time::Span.new(36.57 * 10000)
+          ).to_s).to eq("36.57 milliseconds")
+
+          expect(ElapsedTime.new(
+            started_at,
+            started_at + Time::Span.new(36.573 * 10000)
+          ).to_s).to eq("36.57 milliseconds")
+        end
+      end
+
+      context "when 1 <= total seconds < 60" do
+        it "returns in seconds" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 1.seconds,
+          ).to_s).to eq("1 seconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 34.seconds,
+          ).to_s).to eq("34 seconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 59.seconds,
+          ).to_s).to eq("59 seconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 60.seconds,
+          ).to_s).not_to eq("60 seconds")
+        end
+
+        it "returns in seconds rounded to .2" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 7.seconds,
+          ).to_s).to eq("7 seconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 7.3.seconds,
+          ).to_s).to eq("7.3 seconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 7.34.seconds,
+          ).to_s).to eq("7.34 seconds")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 7.348.seconds,
+          ).to_s).to eq("7.35 seconds")
+        end
+      end
+
+      context "when 1 minute <= elapsed < 1 hour" do
+        it "returns minutes:seconds" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 60.seconds,
+          ).to_s).to eq("1:00 minutes")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 1.3.minutes,
+          ).to_s).to eq("1:18 minutes")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 25.7.minutes,
+          ).to_s).to eq("25:42 minutes")
+        end
+
+        it "formats seconds part as 2 digit 0-padded" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 1.1.minutes,
+          ).to_s).to eq("1:06 minutes")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 69.seconds,
+          ).to_s).to eq("1:09 minutes")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 70.seconds,
+          ).to_s).to eq("1:10 minutes")
+        end
+      end
+
+      context "when total_seconds >= 1 hour" do
+        # pending
+        #it "returns in hours" do
+        #  expect(ElapsedTime.new(
+        #    started_at, started_at + 7.37.hours,
+        #  ).to_s).to eq("7:22:12 hours")
+        #end
+      end
+    end
+  end
+end

--- a/spec/elapsed_time_spec.cr
+++ b/spec/elapsed_time_spec.cr
@@ -95,6 +95,10 @@ module Spec2
           expect(ElapsedTime.new(
             started_at, started_at + 25.7.minutes,
           ).to_s).to eq("25:42 minutes")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 59.99.minutes,
+          ).to_s).to eq("59:59 minutes")
         end
 
         it "formats seconds part as 2 digit 0-padded" do
@@ -113,12 +117,27 @@ module Spec2
       end
 
       context "when total_seconds >= 1 hour" do
-        # pending
-        #it "returns in hours" do
-        #  expect(ElapsedTime.new(
-        #    started_at, started_at + 7.37.hours,
-        #  ).to_s).to eq("7:22:12 hours")
-        #end
+        it "returns in hours" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 60.minutes,
+          ).to_s).to eq("1:00:00 hours")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 7.37.hours,
+          ).to_s).to eq("7:22:12 hours")
+        end
+
+        it "formats seconds part as 2-digits 0-padded" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 60.1.minutes,
+          ).to_s).to eq("1:00:06 hours")
+        end
+
+        it "formats minutes part as 2-digits 0-padded" do
+          expect(ElapsedTime.new(
+            started_at, started_at + 61.minutes,
+          ).to_s).to eq("1:01:00 hours")
+        end
       end
     end
   end

--- a/spec/elapsed_time_spec.cr
+++ b/spec/elapsed_time_spec.cr
@@ -125,6 +125,10 @@ module Spec2
           expect(ElapsedTime.new(
             started_at, started_at + 7.37.hours,
           ).to_s).to eq("7:22:12 hours")
+
+          expect(ElapsedTime.new(
+            started_at, started_at + 7832.26.hours,
+          ).to_s).to eq("7832:15:36 hours")
         end
 
         it "formats seconds part as 2-digits 0-padded" do

--- a/src/elapsed_time.cr
+++ b/src/elapsed_time.cr
@@ -3,7 +3,8 @@ module Spec2
     FORMATTERS = {
       (0...1) => InMilliseconds,
       (1...60) => InSeconds,
-      (60..Float32::INFINITY) => InMinutes,
+      (60...3600) => InMinutes,
+      (3600..Float32::INFINITY) => InHours,
     }
 
     private getter time_now, started_at
@@ -30,6 +31,12 @@ module Spec2
       @_total_seconds ||= elapsed.total_seconds
     end
 
+    record Format2DigitNumber, value do
+      def to_s
+        "%02d" % value
+      end
+    end
+
     record InSeconds, elapsed do
       def to_s
         "#{elapsed.total_seconds.round(2)} seconds"
@@ -48,8 +55,21 @@ module Spec2
       end
 
       private def seconds
-        return elapsed.seconds if elapsed.seconds >= 10
-        "0#{elapsed.seconds}"
+        Format2DigitNumber.new(elapsed.seconds).to_s
+      end
+    end
+
+    record InHours, elapsed do
+      def to_s
+        "#{elapsed.hours}:#{minutes}:#{seconds} hours"
+      end
+
+      private def minutes
+        Format2DigitNumber.new(elapsed.minutes).to_s
+      end
+
+      private def seconds
+        Format2DigitNumber.new(elapsed.seconds).to_s
       end
     end
   end

--- a/src/elapsed_time.cr
+++ b/src/elapsed_time.cr
@@ -1,0 +1,56 @@
+module Spec2
+  class ElapsedTime
+    FORMATTERS = {
+      (0...1) => InMilliseconds,
+      (1...60) => InSeconds,
+      (60..Float32::INFINITY) => InMinutes,
+    }
+
+    private getter time_now, started_at
+    def initialize(@started_at = Spec2.started_at, @time_now = Time.now)
+    end
+
+    def to_s
+      formatter_class.new(elapsed).to_s
+    end
+
+    private def formatter_class
+      FORMATTERS
+        .to_a
+        .find(&.first.includes?(total_seconds))
+        .not_nil!
+        .last
+    end
+
+    private def elapsed
+      time_now - started_at
+    end
+
+    private def total_seconds
+      @_total_seconds ||= elapsed.total_seconds
+    end
+
+    record InSeconds, elapsed do
+      def to_s
+        "#{elapsed.total_seconds.round(2)} seconds"
+      end
+    end
+
+    record InMilliseconds, elapsed do
+      def to_s
+        "#{elapsed.total_milliseconds.round(2)} milliseconds"
+      end
+    end
+
+    record InMinutes, elapsed do
+      def to_s
+        "#{elapsed.minutes}:#{seconds} minutes"
+      end
+
+      private def seconds
+        return elapsed.seconds if elapsed.seconds >= 10
+        "0#{elapsed.seconds}"
+      end
+    end
+  end
+end

--- a/src/elapsed_time.cr
+++ b/src/elapsed_time.cr
@@ -36,6 +36,12 @@ module Spec2
       def to_s
         "%02d" % value
       end
+
+      macro delegate(name, target)
+        def {{name.id}}
+          Format2DigitNumber.new({{target.id}}.{{name.id}}).to_s
+        end
+      end
     end
 
     record InSeconds, elapsed do
@@ -55,9 +61,7 @@ module Spec2
         "#{elapsed.minutes}:#{seconds} minutes"
       end
 
-      private def seconds
-        Format2DigitNumber.new(elapsed.seconds).to_s
-      end
+      Format2DigitNumber.delegate seconds, elapsed
     end
 
     record InHours, elapsed do
@@ -69,13 +73,8 @@ module Spec2
         elapsed.total_hours.to_i
       end
 
-      private def minutes
-        Format2DigitNumber.new(elapsed.minutes).to_s
-      end
-
-      private def seconds
-        Format2DigitNumber.new(elapsed.seconds).to_s
-      end
+      Format2DigitNumber.delegate minutes, elapsed
+      Format2DigitNumber.delegate seconds, elapsed
     end
   end
 end

--- a/src/elapsed_time.cr
+++ b/src/elapsed_time.cr
@@ -1,6 +1,7 @@
 module Spec2
   class ElapsedTime
     FORMATTERS = {
+      # seconds range => formatter class
       (0...1) => InMilliseconds,
       (1...60) => InSeconds,
       (60...3600) => InMinutes,
@@ -61,7 +62,11 @@ module Spec2
 
     record InHours, elapsed do
       def to_s
-        "#{elapsed.hours}:#{minutes}:#{seconds} hours"
+        "#{hours}:#{minutes}:#{seconds} hours"
+      end
+
+      private def hours
+        elapsed.total_hours.to_i
       end
 
       private def minutes

--- a/src/reporter.cr
+++ b/src/reporter.cr
@@ -8,9 +8,5 @@ module Spec2
     abstract def example_failed(example, exception)
     abstract def example_errored(example, exception)
     abstract def report
-
-    private def elapsed_time
-      ElapsedTime.new.to_s
-    end
   end
 end

--- a/src/reporter.cr
+++ b/src/reporter.cr
@@ -10,18 +10,7 @@ module Spec2
     abstract def report
 
     private def elapsed_time
-      elapsed_time = Time.now - Spec2.started_at
-      total_seconds = elapsed_time.total_seconds
-
-      if total_seconds < 1
-        "#{elapsed_time.total_milliseconds.round(2)} milliseconds"
-      elsif total_seconds < 60
-        "#{total_seconds.round(2)} seconds"
-      else
-        minutes = elapsed_time.minutes
-        seconds = elapsed_time.seconds
-        "#{minutes}:#{seconds < 10 ? "0" : ""}#{seconds} minutes"
-      end
+      ElapsedTime.new.to_s
     end
   end
 end

--- a/src/reporters/default.cr
+++ b/src/reporters/default.cr
@@ -49,7 +49,7 @@ module Spec2
 
         output.puts
         status = @errors.size > 0 ? :failure : :success
-        output.puts "Finished in #{elapsed_time}"
+        output.puts "Finished in #{ElapsedTime.new.to_s}"
         output.puts status, "Examples: #{@count}, failures: #{@errors.size}"
       end
     end

--- a/src/reporters/doc.cr
+++ b/src/reporters/doc.cr
@@ -53,7 +53,7 @@ module Spec2
 
         output.puts
         status = @errors.size > 0 ? :failure : :success
-        output.puts "Finished in #{elapsed_time}"
+        output.puts "Finished in #{ElapsedTime.new.to_s}"
         output.puts status, "Examples: #{@count}, failures: #{@errors.size}"
       end
 

--- a/src/spec2.cr
+++ b/src/spec2.cr
@@ -18,6 +18,7 @@ require "./output"
 require "./outputs/*"
 require "./should"
 require "./global_dsl"
+require "./elapsed_time"
 
 module Spec2
   extend self


### PR DESCRIPTION
This PR:
- Extracts without change contents of the `private def elapsed_time` to a class `ElapsedTime` in method `to_s`.
- Extracts moving parts `started_at` and `time_now` as members of the class, that are defaulted to their respective values, but can be injected otherwise.
- Covers code with tests using ReverseTDD techniques.
- Refactors code to be easily change-able.
- Adds missing functionality when elapsed time > 1 hour.
- Removes helper method in abstract interface, instead using `ElapsedTime.new.to_s` directly when needed.
