### PR TITLE
fix #32: Make after hooks run even if example failed

### DIFF
--- a/src/next/dsl.cr
+++ b/src/next/dsl.cr
@@ -107,9 +107,10 @@ module Spec2
           __spec2_before_hook
           __spec2_run_lets!
           {{blk.body}}
-          __spec2_after_hook
 
-          __spec2_delayed.each &.call
+        ensure
+          __spec2_after_hook
+          __spec2_delayed.not_nil!.each &.call
         end
       end
 

--- a/unit_spec/simple_dsl_spec.cr
+++ b/unit_spec/simple_dsl_spec.cr
@@ -418,6 +418,35 @@ end
 
 Spec2::Context.__clear
 evt = empty_evt
+Spec2::DSL.describe "something with after after failure" do
+  H.evt << :root
+
+  after { H.evt << :it_is_cleaning_time }
+
+  it "fails" do
+    H.evt << :before_failure
+    raise "I fail"
+  end
+end
+
+describe "after block when example failed" do
+  example = ::Spec2::Context.contexts[0].examples[0]
+
+  it "still gets executed" do
+    expect_raises do
+      example.run
+    end
+
+    H.evt.should eq([
+      :root,
+      :before_failure,
+      :it_is_cleaning_time
+    ])
+  end
+end
+
+Spec2::Context.__clear
+evt = empty_evt
 Spec2::DSL.describe "uniqueness of context tree" do
   evt << :root
 


### PR DESCRIPTION
This PR makes both `after` and `delayed` hooks run after the example, even if example has failed. This makes sense, if these hooks are used for cleanups. If  they are used for some expectation, it is still OK, since the original exception, will still be raised.
