### PR TITLE
Keep up with new compiler requirements

### DIFF
--- a/issue_macro_must_be_defined_before.cr
+++ b/issue_macro_must_be_defined_before.cr
@@ -1,9 +1,0 @@
-require "./src/spec2"
-
-Spec2.describe "an issue" do
-  it "fails with 'macro must be defined before'" do
-    expect do
-      42
-    end.to raise_error(Exception)
-  end
-end

--- a/issue_macro_must_be_defined_before.cr
+++ b/issue_macro_must_be_defined_before.cr
@@ -1,0 +1,9 @@
+require "./src/spec2"
+
+Spec2.describe "an issue" do
+  it "fails with 'macro must be defined before'" do
+    expect do
+      42
+    end.to raise_error(Exception)
+  end
+end

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,3 @@ license: MIT
 
 authors:
 - Oleksii Fedorov <waterlink000@gmail.com>
-
-development_dependencies:
-  tooling:
-    github: waterlink/tooling.cr

--- a/spec/elapsed_time_spec.cr
+++ b/spec/elapsed_time_spec.cr
@@ -3,7 +3,7 @@ require "../src/elapsed_time"
 
 module Spec2
   Spec2.describe ElapsedTime do
-    let(:started_at) { Time.new(2014, 4, 21, 13, 27, 33, 57) }
+    let(started_at) { Time.new(2014, 4, 21, 13, 27, 33, 57) }
 
     describe "#to_s" do
       context "when seconds < 1" do

--- a/src/elapsed_time.cr
+++ b/src/elapsed_time.cr
@@ -14,7 +14,11 @@ module Spec2
     @_total_seconds : Float64?
 
     private getter time_now, started_at
-    def initialize(@started_at = Spec2.started_at, @time_now = Time.now)
+    def initialize
+      initialize(Spec2.started_at, Time.now)
+    end
+
+    def initialize(@started_at, @time_now)
     end
 
     def to_s

--- a/src/elapsed_time.cr
+++ b/src/elapsed_time.cr
@@ -5,8 +5,13 @@ module Spec2
       (0...1) => InMilliseconds,
       (1...60) => InSeconds,
       (60...3600) => InMinutes,
-      (3600..Float32::INFINITY) => InHours,
+      (3600..Float64::INFINITY) => InHours,
     }
+
+    @started_at : Time
+    @time_now : Time
+
+    @_total_seconds : Float64?
 
     private getter time_now, started_at
     def initialize(@started_at = Spec2.started_at, @time_now = Time.now)
@@ -32,7 +37,7 @@ module Spec2
       @_total_seconds ||= elapsed.total_seconds
     end
 
-    record Format2DigitNumber, value do
+    record Format2DigitNumber, value : Int32 do
       def to_s
         "%02d" % value
       end
@@ -44,19 +49,19 @@ module Spec2
       end
     end
 
-    record InSeconds, elapsed do
+    record InSeconds, elapsed : Time::Span do
       def to_s
         "#{elapsed.total_seconds.round(2)} seconds"
       end
     end
 
-    record InMilliseconds, elapsed do
+    record InMilliseconds, elapsed : Time::Span do
       def to_s
         "#{elapsed.total_milliseconds.round(2)} milliseconds"
       end
     end
 
-    record InMinutes, elapsed do
+    record InMinutes, elapsed : Time::Span do
       def to_s
         "#{elapsed.minutes}:#{seconds} minutes"
       end
@@ -64,7 +69,7 @@ module Spec2
       Format2DigitNumber.delegate seconds, elapsed
     end
 
-    record InHours, elapsed do
+    record InHours, elapsed : Time::Span do
       def to_s
         "#{hours}:#{minutes}:#{seconds} hours"
       end

--- a/src/exceptions.cr
+++ b/src/exceptions.cr
@@ -1,6 +1,6 @@
 module Spec2
   class ExpectationNotMet < Exception
-    getter example
+    getter example : Example?
 
     def with_example(@example)
       self

--- a/src/expectation.cr
+++ b/src/expectation.cr
@@ -1,8 +1,14 @@
 module Spec2
+  module ExpectationProtocol
+    abstract def callback(ok, failure_message, failure_message_when_negated)
+  end
+
   class Expectation(T)
+    include ExpectationProtocol
+
     getter actual
-    getter matcher
-    getter negative
+    getter matcher : Matcher?
+    getter negative : Bool
 
     def initialize(@actual : T)
       @negative = false

--- a/src/factory.cr
+++ b/src/factory.cr
@@ -1,0 +1,9 @@
+module Spec2
+  module Factory
+    macro abstract
+      module Factory
+        abstract def build : {{@type}}
+      end
+    end
+  end
+end

--- a/src/high_runner.cr
+++ b/src/high_runner.cr
@@ -1,8 +1,10 @@
 module Spec2
   class HighRunner
+    @current_runner : Runner?
+
     getter reporter, runner, order, output, root, exit_code
     getter! current_runner
-    def initialize(@root)
+    def initialize(@root : Context)
       @exit_code = 0
     end
 
@@ -10,16 +12,16 @@ module Spec2
       [root]
     end
 
-    def configure_reporter(@reporter)
+    def configure_reporter(@reporter : Reporter::Factory)
     end
 
-    def configure_runner(@runner)
+    def configure_runner(@runner : Runner::Factory)
     end
 
-    def configure_order(@order)
+    def configure_order(@order : Order::Factory)
     end
 
-    def configure_output(@output)
+    def configure_output(@output : Output::Factory)
     end
 
     def want_exit(@exit_code)
@@ -54,10 +56,10 @@ module Spec2
         )
       end
 
-      reporter = reporter_class.new
-      @current_runner = runner_class.new
-      order = order_class.new
-      output = output_class.new
+      reporter = reporter_class.build
+      @current_runner = runner_class.build
+      order = order_class.build
+      output = output_class.build
 
       reporter.configure_output(output)
 

--- a/src/matchers/be.cr
+++ b/src/matchers/be.cr
@@ -1,26 +1,28 @@
 module Spec2
   module Matchers
-    class Be
+    class Be(T)
       include Matcher
-      getter expected, actual
+      getter expected
+      getter actual_representation : String?
 
-      def initialize(@expected)
+      def initialize(@expected : T)
       end
 
-      def match(@actual)
+      def match(actual)
+        @actual_representation = actual.inspect
         expected.same?(actual)
       end
 
       def failure_message
         "Expected to be the same:
         Expected: #{expected.inspect}
-        Actual:   #{actual.inspect}"
+        Actual:   #{actual_representation}"
       end
 
       def failure_message_when_negated
         "Expected to be different:
         Expected: #{expected.inspect}
-        Actual:   #{actual.inspect}"
+        Actual:   #{actual_representation}"
       end
 
       def description
@@ -29,7 +31,8 @@ module Spec2
     end
 
     class BeRecorder(T)
-      def initialize(@actual : T, @expectation); end
+      def initialize(@actual : T, @expectation : ExpectationProtocol)
+      end
 
       macro method_missing(name, args, block)
         ok = !!(@actual.{{name.id}}({{args.argify}}) {{block}})

--- a/src/matchers/be_a.cr
+++ b/src/matchers/be_a.cr
@@ -2,18 +2,19 @@ module Spec2
   module Matchers
     class BeA(T)
       include Matcher
-      getter actual
+      getter actual_representation : String?
 
-      def match(@actual)
+      def match(actual)
+        @actual_representation = actual.inspect
         actual.is_a?(T)
       end
 
       def failure_message
-        "Expected #{actual.inspect} to be a #{T}"
+        "Expected #{actual_representation} to be a #{T}"
       end
 
       def failure_message_when_negated
-        "Expected #{actual.inspect} not to be a #{T}"
+        "Expected #{actual_representation} not to be a #{T}"
       end
 
       def description

--- a/src/matchers/bool.cr
+++ b/src/matchers/bool.cr
@@ -2,18 +2,19 @@ module Spec2
   module Matchers
     class BeTruthy
       include Matcher
-      getter actual
+      getter actual_representation : String?
 
-      def match(@actual)
+      def match(actual)
+        @actual_representation = actual.inspect
         !!actual
       end
 
       def failure_message
-        "Expected #{actual.inspect} to be truthy"
+        "Expected #{actual_representation} to be truthy"
       end
 
       def failure_message_when_negated
-        "Expeccted #{actual.inspect} not to be truthy"
+        "Expeccted #{actual_representation} not to be truthy"
       end
 
       def description
@@ -23,18 +24,19 @@ module Spec2
 
     class BeFalsey
       include Matcher
-      getter actual
+      getter actual_representation : String?
 
-      def match(@actual)
+      def match(actual)
+        @actual_representation = actual.inspect
         !actual
       end
 
       def failure_message
-        "Expected #{actual.inspect} to be falsey"
+        "Expected #{actual_representation} to be falsey"
       end
 
       def failure_message_when_negated
-        "Expeccted #{actual.inspect} not to be falsey"
+        "Expeccted #{actual_representation} not to be falsey"
       end
 
       def description

--- a/src/matchers/close.cr
+++ b/src/matchers/close.cr
@@ -1,13 +1,15 @@
 module Spec2
   module Matchers
-    class Close
+    class Close(T, E)
       include Matcher
-      getter actual, expected, delta
-      getter! actual_delta
+      getter expected, delta
+      getter actual_representation : String?
+      getter! actual_delta : T|E?
 
-      def initialize(@expected, @delta); end
+      def initialize(@expected : T, @delta : E); end
 
-      def match(@actual)
+      def match(actual)
+        @actual_representation = actual.inspect
         @actual_delta = (actual - expected).abs
         actual_delta < delta
       end
@@ -15,7 +17,7 @@ module Spec2
       def failure_message
         "Expected to be close:
         Expected:  #{expected.inspect}
-        Actual:    #{actual.inspect}
+        Actual:    #{actual_representation}
         Max-delta: #{delta.inspect}
         Delta:     #{actual_delta.inspect}"
       end
@@ -23,7 +25,7 @@ module Spec2
       def failure_message_when_negated
         "Expected to be not close:
         Expected:  #{expected.inspect}
-        Actual:    #{actual.inspect}
+        Actual:    #{actual_representation}
         Min-delta: #{delta.inspect}
         Delta:     #{actual_delta.inspect}"
       end

--- a/src/matchers/eq.cr
+++ b/src/matchers/eq.cr
@@ -1,22 +1,24 @@
 module Spec2
   module Matchers
-    class Eq
+    class Eq(T)
       include Matcher
       getter expected
-      getter actual
+      getter actual_representation : String?
 
-      def initialize(@expected); end
+      def initialize(@expected : T)
+      end
 
-      def match(@actual)
+      def match(actual)
+        @actual_representation = actual.inspect
         expected == actual
       end
 
       def failure_message
-        "Expected to be equal:\n\t\tExpected:\t #{expected.inspect}\n\t\tActual:\t\t #{actual.inspect}\n"
+        "Expected to be equal:\n\t\tExpected:\t #{expected.inspect}\n\t\tActual:\t\t #{actual_representation}\n"
       end
 
       def failure_message_when_negated
-        "Expected not to be equal:\n\t\tExpected;\t #{expected.inspect}\n\t\tActual:\t\t #{actual.inspect}\n"
+        "Expected not to be equal:\n\t\tExpected;\t #{expected.inspect}\n\t\tActual:\t\t #{actual_representation}\n"
       end
 
       def description

--- a/src/matchers/match.cr
+++ b/src/matchers/match.cr
@@ -1,25 +1,29 @@
 module Spec2
   module Matchers
-    class Match
+    class Match(T)
       include Matcher
-      getter expected, actual
 
-      def initialize(@expected); end
+      getter expected
+      getter actual_representation : String?
 
-      def match(@actual)
+      def initialize(@expected : T)
+      end
+
+      def match(actual)
+        @actual_representation = actual.inspect
         !!(actual =~ expected)
       end
 
       def failure_message
         "Expected to match:
         Expected: #{expected.inspect}
-        Actual:   #{actual.inspect}"
+        Actual:   #{actual_representation}"
       end
 
       def failure_message_when_negated
         "Expected not to match:
         Expected: #{expected.inspect}
-        Actual:   #{actual.inspect}"
+        Actual:   #{actual_representation}"
       end
 
       def description

--- a/src/matchers/satisfy.cr
+++ b/src/matchers/satisfy.cr
@@ -1,6 +1,11 @@
 module Spec2
   module Matchers
     class Satisfy(T)
+      include Matcher
+
+      @failure_message : String?
+      @failure_message_when_negated : String?
+
       getter! failure_message, failure_message_when_negated
       def initialize(&@block : T -> {Bool, String, String})
       end

--- a/src/next/context.cr
+++ b/src/next/context.cr
@@ -16,12 +16,16 @@ module Spec2
     end
 
     getter what, description
-    def initialize(parent, @what)
+    def initialize(parent, @what : String)
       @description = what
 
       if parent && !parent.description.to_s.empty?
         @description = "#{parent.description} #{what}"
       end
+    end
+
+    def initialize(parent, what)
+      initialize(parent, what.to_s)
     end
 
     def contexts
@@ -39,6 +43,7 @@ module Spec2
     module Inside
       include DSL
 
+      @@__spec2_active_context : Context
       @@__spec2_active_context = Context.instance
     end
   end

--- a/src/next/context.cr
+++ b/src/next/context.cr
@@ -1,6 +1,5 @@
 module Spec2
   class Context
-    CURRENT = {"get" => ::Spec2::Context::Inside}
     DEFINED = {} of String => Bool
 
     def self.instance
@@ -38,13 +37,6 @@ module Spec2
 
     def __clear
       @_contexts = nil
-    end
-
-    module Inside
-      include DSL
-
-      @@__spec2_active_context : Context
-      @@__spec2_active_context = Context.instance
     end
   end
 end

--- a/src/next/dsl.cr
+++ b/src/next/dsl.cr
@@ -180,16 +180,16 @@ module Spec2
       @_{{name.id}} : LetProtocol?
 
       def {{name.id}}
-        (@_{{name.id}} ||= {{name.id}}!).unwrap as typeof(__spec2_for_typeof_{{name.id}})
+        (@_{{name.id}} ||= {{name.id}}!).unwrap as typeof(__spec2_well_typed_let__{{name.id}})
       end
 
       def {{name.id}}!
         Let.new do
-          {{blk.body}}
+          __spec2_well_typed_let__{{name.id}}
         end
       end
 
-      def __spec2_for_typeof_{{name.id}}
+      def __spec2_well_typed_let__{{name.id}}
         {{blk.body}}
       end
     end

--- a/src/next/dsl.cr
+++ b/src/next/dsl.cr
@@ -24,12 +24,19 @@ module Spec2
 
     macro describe(what, file = __FILE__, line = __LINE__, &blk)
       {% if SPEC2_FULL_CONTEXT == ":root" %}
+        module Spec2___Root
+        @@__spec2_active_context : ::Spec2::Context
+        @@__spec2_active_context = ::Spec2::Context.instance
         ::Spec2::DSL.context(
       {% else %}
         context(
       {% end %}
         {{what}}, {{file}}, {{line}}
       ) {{blk}}
+
+      {% if SPEC2_FULL_CONTEXT == ":root" %}
+        {{:end.id}}
+      {% end %}
     end
 
     macro context(what, file = __FILE__, line = __LINE__, &blk)
@@ -98,7 +105,6 @@ module Spec2
 
         def initialize(@context)
           @what = {{what}}
-          @blk = -> {}
         end
 
         def run

--- a/src/next/dsl.cr
+++ b/src/next/dsl.cr
@@ -3,8 +3,20 @@ module Spec2
     include Matchers
     extend Matchers
 
+    module HasActiveContext
+      macro included
+        @@__spec2_active_context : ::Spec2::Context
+        def self.__spec2_active_context
+          @@__spec2_active_context
+        end
+      end
+    end
+
     module Spec2___
       include ::Spec2::DSL
+      include ::Spec2::DSL::HasActiveContext
+
+      @@__spec2_active_context = ::Spec2::Context.instance
 
       def __spec2_before_hook
       end
@@ -48,6 +60,10 @@ module Spec2
       %current_context = @@__spec2_active_context
       module {{name.id}}
         include {{SPEC2_CONTEXT}}
+        include ::Spec2::DSL::HasActiveContext
+
+        @@__spec2_active_context = ::Spec2::Context
+          .new({{SPEC2_CONTEXT}}.__spec2_active_context, {{what}})
 
         {% unless ::Spec2::Context::DEFINED[full_name] == true %}
           SPEC2_FULL_CONTEXT = {{full_name}}
@@ -61,9 +77,6 @@ module Spec2
         {% end %}
 
         __spec2_sanity_checks({{name}}, {{full_name}})
-
-        @@__spec2_active_context = ::Spec2::Context
-          .new(%current_context, {{what}})
 
         (%current_context ||
          ::Spec2::Context.instance)

--- a/src/next/example.cr
+++ b/src/next/example.cr
@@ -1,7 +1,12 @@
 module Spec2
   class Example
+    @_description : String?
+
+    @context : Context
+    @what : String
+
     getter context, what
-    def initialize(@context, @what, &@blk : ->)
+    def initialize(@context, @what)
     end
 
     def description
@@ -9,7 +14,6 @@ module Spec2
     end
 
     def run
-      @blk.call
     end
 
     def __spec2_clear_lets

--- a/src/order.cr
+++ b/src/order.cr
@@ -1,5 +1,6 @@
 module Spec2
   module Order
+    Factory.abstract
     abstract def order(list)
   end
 end

--- a/src/orders/default.cr
+++ b/src/orders/default.cr
@@ -2,6 +2,11 @@ module Spec2
   module Orders
     class Default
       include Order
+      extend Order::Factory
+
+      def self.build
+        new
+      end
 
       def order(list)
         list

--- a/src/orders/random.cr
+++ b/src/orders/random.cr
@@ -2,6 +2,11 @@ module Spec2
   module Orders
     class Random
       include Order
+      extend Order::Factory
+
+      def self.build
+        new
+      end
 
       def order(list)
         list.shuffle

--- a/src/output.cr
+++ b/src/output.cr
@@ -1,5 +1,7 @@
 module Spec2
-   module Output
+  module Output
+    Factory.abstract
+    
     abstract def print(style, string)
 
     def print(string)

--- a/src/outputs/default.cr
+++ b/src/outputs/default.cr
@@ -2,11 +2,16 @@ module Spec2
   module Outputs
     class Default
       include Output
+      extend Output::Factory
 
       COLORS = {
         success: :green,
         failure: :red,
       }
+
+      def self.build
+        new
+      end
 
       def print(style, string)
         return io_print(string) if style == :normal

--- a/src/outputs/nocolor.cr
+++ b/src/outputs/nocolor.cr
@@ -2,6 +2,11 @@ module Spec2
   module Outputs
     class Nocolor
       include Output
+      extend Output::Factory
+
+      def self.build
+        new
+      end
 
       def print(style, string)
         STDOUT.print(string)

--- a/src/reporter.cr
+++ b/src/reporter.cr
@@ -1,5 +1,6 @@
 module Spec2
   module Reporter
+    Factory.abstract
     abstract def configure_output(output)
     abstract def context_started(context)
     abstract def context_finished(context)

--- a/src/reporters/default.cr
+++ b/src/reporters/default.cr
@@ -2,6 +2,11 @@ module Spec2
   module Reporters
     class Default
       include Reporter
+      extend Reporter::Factory
+
+      def self.build
+        new
+      end
 
       getter! output
       def initialize
@@ -9,7 +14,7 @@ module Spec2
         @errors = [] of ExpectationNotMet
       end
 
-      def configure_output(@output)
+      def configure_output(@output : Output)
       end
 
       def context_started(context)

--- a/src/reporters/doc.cr
+++ b/src/reporters/doc.cr
@@ -2,6 +2,11 @@ module Spec2
   module Reporters
     class Doc
       include Reporter
+      extend Reporter::Factory
+
+      def self.build
+        new
+      end
 
       getter! output, nesting
       def initialize
@@ -10,7 +15,7 @@ module Spec2
         @nesting = 0
       end
 
-      def configure_output(@output)
+      def configure_output(@output : Output)
       end
 
       def context_started(context)

--- a/src/reporters/test.cr
+++ b/src/reporters/test.cr
@@ -3,11 +3,17 @@ module Spec2
     struct TestEvent
       property event, example, exception
 
-      def initialize(@event, @example, @exception); end
+      def initialize(@event : Symbol, @example : Example?, @exception : Exception?)
+      end
     end
 
     class Test
       include Reporter
+      extend Reporter::Factory
+
+      def self.build
+        new
+      end
 
       getter received
       def initialize

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -1,5 +1,6 @@
 module Spec2
   module Runner
+    Factory.abstract
     abstract def run_context(reporter, order, context)
     abstract def current_context
     abstract def failed?

--- a/src/runners/default.cr
+++ b/src/runners/default.cr
@@ -2,7 +2,13 @@ module Spec2
   module Runners
     class Default
       include Runner
+      extend Runner::Factory
 
+      def self.build
+        new
+      end
+
+      @current_context : Context?
       getter current_context
 
       def failed?

--- a/src/spec2.cr
+++ b/src/spec2.cr
@@ -1,5 +1,7 @@
 require "colorize"
 
+require "./factory"
+
 require "./matcher"
 require "./matchers/*"
 require "./exceptions"
@@ -24,6 +26,8 @@ module Spec2
   extend self
 
   @@high_runner = HighRunner.new(Context.instance)
+
+  @@started_at : Time
   @@started_at = Time.now
 
   def high_runner

--- a/src/spec2.cr
+++ b/src/spec2.cr
@@ -27,15 +27,18 @@ module Spec2
 
   @@high_runner = HighRunner.new(Context.instance)
 
-  @@started_at : Time
-  @@started_at = Time.now
+  @@started_at : Time?
 
   def high_runner
     @@high_runner
   end
 
+  def record_started_at
+    @@started_at = Time.now
+  end
+
   def started_at
-    @@started_at
+    @@started_at.not_nil!
   end
 
   def configure_high_runner(@@high_runner)
@@ -57,6 +60,8 @@ module Spec2
     ::Spec2::DSL.describe({{what}}, {{file}}, {{line}}) {{block}}
   end
 end
+
+Spec2.record_started_at
 
 Spec2.configure_runner(Spec2::Runners::Default)
 Spec2.configure_reporter(Spec2::Reporters::Default)

--- a/unit_spec/delayed_spec.cr
+++ b/unit_spec/delayed_spec.cr
@@ -1,31 +1,33 @@
 require "./spec_helper"
 
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with delayed" do
-  let(answers) { {"life" => 74} }
+module DelayedSpec
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with delayed" do
+    let(answers) { {"life" => 74} }
 
-  after { answers["life"] -= 12 }
+    after { answers["life"] -= 12 }
 
-  it "passes" do
-    delayed { answers["life"].should H.eq(42) }
-    answers["life"] -= 20
+    it "passes" do
+      delayed { answers["life"].should H.eq(42) }
+      answers["life"] -= 20
+    end
+
+    it "fails" do
+      delayed { answers["life"].should H.eq(42) }
+    end
   end
 
-  it "fails" do
-    delayed { answers["life"].should H.eq(42) }
-  end
-end
+  describe "delayed statement" do
+    passes = ::Spec2::Context.contexts[0].examples[0]
+    fails = ::Spec2::Context.contexts[0].examples[1]
 
-describe "delayed statement" do
-  passes = ::Spec2::Context.contexts[0].examples[0]
-  fails = ::Spec2::Context.contexts[0].examples[1]
+    it "runs after the example and after" do
+      passes.run
 
-  it "runs after the example and after" do
-    passes.run
-
-    expect_raises ::Spec::AssertionFailed do
-      fails.run
+      expect_raises ::Spec::AssertionFailed do
+        fails.run
+      end
     end
   end
 end

--- a/unit_spec/simple_dsl_spec.cr
+++ b/unit_spec/simple_dsl_spec.cr
@@ -1,491 +1,495 @@
 require "./spec_helper"
 
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something" do
-  evt << :described_something
-end
+module SimpleDSLSpec
+  @@__spec2_active_context : ::Spec2::Context?
 
-describe "describe statement" do
-  it "creates a context" do
-    Spec2::Context.contexts[0].what
-      .should H.eq("something")
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something" do
+    evt << :described_something
   end
 
-  it "runs content of context" do
-    evt.should H.eq([:described_something])
-  end
-end
+  describe "describe statement" do
+    it "creates a context" do
+      Spec2::Context.contexts[0].what
+        .should H.eq("something")
+    end
 
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.context "when something" do
-  evt << :context_when_something
-end
-
-describe "context statement" do
-  it "creates a context" do
-    Spec2::Context.contexts[0].what
-      .should H.eq("when something")
-
-    Spec2::Context.contexts[0].description
-      .should H.eq("when something")
+    it "runs content of context" do
+      evt.should H.eq([:described_something])
+    end
   end
 
-  it "runs content of context" do
-    evt.should H.eq([:context_when_something])
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.context "something with inner context" do
-  evt << :context_when_something
-
-  context "when something else" do
-    evt << :context_when_something_else
-  end
-end
-
-describe "inner context" do
-  it "creates a context" do
-    Spec2::Context.contexts[0].what
-      .should H.eq("something with inner context")
-
-    Spec2::Context.contexts[0].description
-      .should H.eq("something with inner context")
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.context "when something" do
+    evt << :context_when_something
   end
 
-  it "creates an inner context" do
-    Spec2::Context.contexts[0].contexts[0].what
-      .should H.eq("when something else")
+  describe "context statement" do
+    it "creates a context" do
+      Spec2::Context.contexts[0].what
+        .should H.eq("when something")
 
-    Spec2::Context.contexts[0].contexts[0].description
-      .should H.eq("something with inner context when something else")
+      Spec2::Context.contexts[0].description
+        .should H.eq("when something")
+    end
+
+    it "runs content of context" do
+      evt.should H.eq([:context_when_something])
+    end
   end
 
-  it "runs content of context and inner context" do
-    evt.should H.eq([:context_when_something, :context_when_something_else])
-  end
-end
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.context "something with inner context" do
+    evt << :context_when_something
 
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with it" do
-  evt << :described_something
-
-  it "works" do
-    H.evt << :it_works
-  end
-end
-
-describe "it statement" do
-  example = Spec2::Context.contexts[0].examples[0]
-
-  it "defines an example" do
-    example.what.should H.eq("works")
-
-    example.description.should H.eq("something with it works")
+    context "when something else" do
+      evt << :context_when_something_else
+    end
   end
 
-  it "does not execute block right away" do
-    evt.should H.eq([:described_something])
+  describe "inner context" do
+    it "creates a context" do
+      Spec2::Context.contexts[0].what
+        .should H.eq("something with inner context")
+
+      Spec2::Context.contexts[0].description
+        .should H.eq("something with inner context")
+    end
+
+    it "creates an inner context" do
+      Spec2::Context.contexts[0].contexts[0].what
+        .should H.eq("when something else")
+
+      Spec2::Context.contexts[0].contexts[0].description
+        .should H.eq("something with inner context when something else")
+    end
+
+    it "runs content of context and inner context" do
+      evt.should H.eq([:context_when_something, :context_when_something_else])
+    end
   end
 
-  it "is possible to execute a block" do
-    example.run
-    evt.should H.eq([:described_something, :it_works])
-  end
-end
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with it" do
+    evt << :described_something
 
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with let" do
-  evt << :described_something
-
-  let(greeting) { H.evt << :define_let; "hello world" }
-
-  it "works" do
-    H.evt << :it_works
-    greeting.should H.eq("hello world")
-  end
-end
-
-describe "let statement" do
-  example = Spec2::Context.contexts[0].examples[0]
-
-  it "does not execute let block right away" do
-    evt.should H.eq([:described_something])
+    it "works" do
+      H.evt << :it_works
+    end
   end
 
-  it "executes let and it blocks once when run" do
-    example.run
-    evt.should H.eq([
-      :described_something,
-      :it_works,
-      :define_let,
-    ])
+  describe "it statement" do
+    example = Spec2::Context.contexts[0].examples[0]
+
+    it "defines an example" do
+      example.what.should H.eq("works")
+
+      example.description.should H.eq("something with it works")
+    end
+
+    it "does not execute block right away" do
+      evt.should H.eq([:described_something])
+    end
+
+    it "is possible to execute a block" do
+      example.run
+      evt.should H.eq([:described_something, :it_works])
+    end
   end
 
-  it "can execute example multiple times, but not let" do
-    example.run
-    example.run
-    example.run
-    evt.should H.eq([
-      :described_something,
-      :it_works,
-      :define_let,
-      :it_works,
-      :it_works,
-      :it_works,
-    ])
-  end
-end
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with let" do
+    evt << :described_something
 
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with let bang" do
-  let!(greeting) { H.evt << :define_let; "hello world" }
+    let(greeting) { H.evt << :define_let; "hello world" }
 
-  it "does not call let" do
-    H.evt << :it_does_not
-  end
-
-  it "calls let" do
-    H.evt << :it_calls
-    greeting.should H.eq("hello world")
-  end
-end
-
-describe "let! statement" do
-  does_not = Spec2::Context.contexts[0].examples[0]
-  calls = Spec2::Context.contexts[0].examples[1]
-
-  it "does not execute let block right away" do
-    evt.should H.eq([] of Symbol)
-  end
-
-  it "executes let block when is not used" do
-    does_not.run
-    evt.should H.eq([
-      :define_let,
-      :it_does_not,
-    ])
-  end
-
-  it "executes let block when used" do
-    calls.run
-    evt.should H.eq([
-      :define_let,
-      :it_does_not,
-      :define_let,
-      :it_calls,
-    ])
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "inherited lets" do
-  let(greeting) { H.evt << :define_let; "#{word} #{name}" }
-
-  context "when greeting the world" do
-    let(word) { "hello" }
-    let(name) { "world" }
-
-    it "is a first program" do
+    it "works" do
+      H.evt << :it_works
       greeting.should H.eq("hello world")
     end
   end
 
-  context "when greeting an acquaintance" do
-    let(word) { "hey" }
-    let(name) { "John" }
+  describe "let statement" do
+    example = Spec2::Context.contexts[0].examples[0]
 
-    it "is an informal greeting" do
-      greeting.should H.eq("hey John")
+    it "does not execute let block right away" do
+      evt.should H.eq([:described_something])
     end
 
-    context "when greeter is lazy" do
-      let(greeting) { "Hi!" }
+    it "executes let and it blocks once when run" do
+      example.run
+      evt.should H.eq([
+        :described_something,
+        :it_works,
+        :define_let,
+      ])
+    end
 
-      it "is a lazy form of greeting" do
-        greeting.should H.eq("Hi!")
+    it "can execute example multiple times, but not let" do
+      example.run
+      example.run
+      example.run
+      evt.should H.eq([
+        :described_something,
+        :it_works,
+        :define_let,
+        :it_works,
+        :it_works,
+        :it_works,
+      ])
+    end
+  end
+
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with let bang" do
+    let!(greeting) { H.evt << :define_let; "hello world" }
+
+    it "does not call let" do
+      H.evt << :it_does_not
+    end
+
+    it "calls let" do
+      H.evt << :it_calls
+      greeting.should H.eq("hello world")
+    end
+  end
+
+  describe "let! statement" do
+    does_not = Spec2::Context.contexts[0].examples[0]
+    calls = Spec2::Context.contexts[0].examples[1]
+
+    it "does not execute let block right away" do
+      evt.should H.eq([] of Symbol)
+    end
+
+    it "executes let block when is not used" do
+      does_not.run
+      evt.should H.eq([
+        :define_let,
+        :it_does_not,
+      ])
+    end
+
+    it "executes let block when used" do
+      calls.run
+      evt.should H.eq([
+        :define_let,
+        :it_does_not,
+        :define_let,
+        :it_calls,
+      ])
+    end
+  end
+
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "inherited lets" do
+    let(greeting) { H.evt << :define_let; "#{word} #{name}" }
+
+    context "when greeting the world" do
+      let(word) { "hello" }
+      let(name) { "world" }
+
+      it "is a first program" do
+        greeting.should H.eq("hello world")
       end
     end
 
-    context "when acquaintance is Joe" do
-      let(name) { "Joe" }
+    context "when greeting an acquaintance" do
+      let(word) { "hey" }
+      let(name) { "John" }
 
-      it "is an informal greeting for Joe" do
-        greeting.should H.eq("hey Joe")
+      it "is an informal greeting" do
+        greeting.should H.eq("hey John")
+      end
+
+      context "when greeter is lazy" do
+        let(greeting) { "Hi!" }
+
+        it "is a lazy form of greeting" do
+          greeting.should H.eq("Hi!")
+        end
+      end
+
+      context "when acquaintance is Joe" do
+        let(name) { "Joe" }
+
+        it "is an informal greeting for Joe" do
+          greeting.should H.eq("hey Joe")
+        end
+      end
+
+      context "when greeter is nice" do
+        let(greeting) { "#{super}! How are you?" }
+
+        it "is a nice form of greeting" do
+          greeting.should H.eq("hey John! How are you?")
+        end
       end
     end
+  end
 
-    context "when greeter is nice" do
-      let(greeting) { "#{super}! How are you?" }
+  describe "inherited lets" do
+    examples = [
+      ::Spec2::Context.contexts[0].contexts[0].examples[0],
+      ::Spec2::Context.contexts[0].contexts[1].examples[0],
+      ::Spec2::Context.contexts[0].contexts[1].contexts[0].examples[0],
+      ::Spec2::Context.contexts[0].contexts[1].contexts[1].examples[0],
+      ::Spec2::Context.contexts[0].contexts[1].contexts[2].examples[0],
+    ]
 
-      it "is a nice form of greeting" do
-        greeting.should H.eq("hey John! How are you?")
-      end
+    it "passes" do
+      examples.each &.run
     end
   end
-end
 
-describe "inherited lets" do
-  examples = [
-    ::Spec2::Context.contexts[0].contexts[0].examples[0],
-    ::Spec2::Context.contexts[0].contexts[1].examples[0],
-    ::Spec2::Context.contexts[0].contexts[1].contexts[0].examples[0],
-    ::Spec2::Context.contexts[0].contexts[1].contexts[1].examples[0],
-    ::Spec2::Context.contexts[0].contexts[1].contexts[2].examples[0],
-  ]
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with subject" do
+    subject { "hello world" }
 
-  it "passes" do
-    examples.each &.run
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with subject" do
-  subject { "hello world" }
-
-  it "works" do
-    subject.should H.eq("hello world")
-  end
-end
-
-describe "subject statement" do
-  example = ::Spec2::Context.contexts[0].examples[0]
-
-  it "works as let(subject)" do
-    example.run
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with subject bang" do
-  subject! { H.evt << :subject_defined; "hello world" }
-
-  it "does not" do
-    H.evt << :does_not
-  end
-
-  it "calls" do
-    H.evt << :calls
-    subject.should H.eq("hello world")
-  end
-end
-
-describe "subject bang statement" do
-  does_not = ::Spec2::Context.contexts[0].examples[0]
-  calls = ::Spec2::Context.contexts[0].examples[1]
-
-  it "works as let!(subject)" do
-    evt.should H.eq([] of Symbol)
-
-    does_not.run
-    evt.should H.eq([:subject_defined, :does_not])
-
-    calls.run
-    evt.should H.eq([
-      :subject_defined,
-      :does_not,
-      :subject_defined,
-      :calls,
-    ])
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "named subject" do
-  subject(greeting) { "hello world" }
-
-  it "works" do
-    greeting.should H.eq("hello world")
-  end
-end
-
-describe "named subject statement" do
-  example = ::Spec2::Context.contexts[0].examples[0]
-
-  it "works as let(name)" do
-    example.run
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "named subject bang" do
-  subject!(greeting) { H.evt << :subject_defined; "hello world" }
-
-  it "does not" do
-    H.evt << :does_not
-  end
-
-  it "calls" do
-    H.evt << :calls
-    greeting.should H.eq("hello world")
-  end
-end
-
-describe "named subject bang statement" do
-  does_not = ::Spec2::Context.contexts[0].examples[0]
-  calls = ::Spec2::Context.contexts[0].examples[1]
-
-  it "works as let!(subject)" do
-    evt.should H.eq([] of Symbol)
-
-    does_not.run
-    evt.should H.eq([:subject_defined, :does_not])
-
-    calls.run
-    evt.should H.eq([
-      :subject_defined,
-      :does_not,
-      :subject_defined,
-      :calls,
-    ])
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with before and after" do
-  evt << :described_something
-
-  let(stuff) { 42 }
-
-  after { H.evt << :after_a }
-  before { H.evt << :before_a }
-  before { H.evt << :"before_b" if stuff == 42 }
-  after { H.evt << :after_b }
-  before { H.evt << :before_c }
-  after { H.evt << :after_c }
-
-  it "works" do
-    H.evt << :works
-  end
-
-  context "when stuff is not 42" do
-    let(stuff) { super - 1 }
-
-    before { H.evt << :inner_before }
-    after { H.evt << :inner_after }
-
-    it "works too" do
-      H.evt << :works_too
+    it "works" do
+      subject.should H.eq("hello world")
     end
   end
-end
 
-describe "before and after" do
-  examples = [
-    ::Spec2::Context.contexts[0].examples[0],
-    ::Spec2::Context.contexts[0].contexts[0].examples[0],
-  ]
+  describe "subject statement" do
+    example = ::Spec2::Context.contexts[0].examples[0]
 
-  it "runs hooks in right order" do
-    evt.should H.eq([:described_something])
-
-    examples.each &.run
-
-    evt.should H.eq([
-      :described_something,
-
-      :before_a,
-      :before_b,
-      :before_c,
-      :works,
-      :after_a,
-      :after_b,
-      :after_c,
-
-      :before_a,
-      :before_c,
-      :inner_before,
-      :works_too,
-      :after_a,
-      :after_b,
-      :after_c,
-      :inner_after,
-    ])
-  end
-end
-
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "something with after after failure" do
-  H.evt << :root
-
-  after { H.evt << :it_is_cleaning_time }
-
-  it "fails" do
-    H.evt << :before_failure
-    raise "I fail"
-  end
-end
-
-describe "after block when example failed" do
-  example = ::Spec2::Context.contexts[0].examples[0]
-
-  it "still gets executed" do
-    expect_raises do
+    it "works as let(subject)" do
       example.run
     end
-
-    H.evt.should eq([
-      :root,
-      :before_failure,
-      :it_is_cleaning_time
-    ])
   end
-end
 
-Spec2::Context.__clear
-evt = empty_evt
-Spec2::DSL.describe "uniqueness of context tree" do
-  evt << :root
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with subject bang" do
+    subject! { H.evt << :subject_defined; "hello world" }
 
-  context "context a" do
-    before { H.evt << :context_a }
+    it "does not" do
+      H.evt << :does_not
+    end
+
+    it "calls" do
+      H.evt << :calls
+      subject.should H.eq("hello world")
+    end
+  end
+
+  describe "subject bang statement" do
+    does_not = ::Spec2::Context.contexts[0].examples[0]
+    calls = ::Spec2::Context.contexts[0].examples[1]
+
+    it "works as let!(subject)" do
+      evt.should H.eq([] of Symbol)
+
+      does_not.run
+      evt.should H.eq([:subject_defined, :does_not])
+
+      calls.run
+      evt.should H.eq([
+        :subject_defined,
+        :does_not,
+        :subject_defined,
+        :calls,
+      ])
+    end
+  end
+
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "named subject" do
+    subject(greeting) { "hello world" }
+
+    it "works" do
+      greeting.should H.eq("hello world")
+    end
+  end
+
+  describe "named subject statement" do
+    example = ::Spec2::Context.contexts[0].examples[0]
+
+    it "works as let(name)" do
+      example.run
+    end
+  end
+
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "named subject bang" do
+    subject!(greeting) { H.evt << :subject_defined; "hello world" }
+
+    it "does not" do
+      H.evt << :does_not
+    end
+
+    it "calls" do
+      H.evt << :calls
+      greeting.should H.eq("hello world")
+    end
+  end
+
+  describe "named subject bang statement" do
+    does_not = ::Spec2::Context.contexts[0].examples[0]
+    calls = ::Spec2::Context.contexts[0].examples[1]
+
+    it "works as let!(subject)" do
+      evt.should H.eq([] of Symbol)
+
+      does_not.run
+      evt.should H.eq([:subject_defined, :does_not])
+
+      calls.run
+      evt.should H.eq([
+        :subject_defined,
+        :does_not,
+        :subject_defined,
+        :calls,
+      ])
+    end
+  end
+
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with before and after" do
+    evt << :described_something
+
+    let(stuff) { 42 }
+
+    after { H.evt << :after_a }
+    before { H.evt << :before_a }
+    before { H.evt << :"before_b" if stuff == 42 }
+    after { H.evt << :after_b }
+    before { H.evt << :before_c }
+    after { H.evt << :after_c }
 
     it "works" do
       H.evt << :works
     end
-  end
 
-  context "inner" do
-    context "context a" do
-      before { H.evt << :inner_context_a }
+    context "when stuff is not 42" do
+      let(stuff) { super - 1 }
+
+      before { H.evt << :inner_before }
+      after { H.evt << :inner_after }
 
       it "works too" do
         H.evt << :works_too
       end
     end
+  end
 
-    context "random context inside" do
+  describe "before and after" do
+    examples = [
+      ::Spec2::Context.contexts[0].examples[0],
+      ::Spec2::Context.contexts[0].contexts[0].examples[0],
+    ]
+
+    it "runs hooks in right order" do
+      evt.should H.eq([:described_something])
+
+      examples.each &.run
+
+      evt.should H.eq([
+        :described_something,
+
+        :before_a,
+        :before_b,
+        :before_c,
+        :works,
+        :after_a,
+        :after_b,
+        :after_c,
+
+        :before_a,
+        :before_c,
+        :inner_before,
+        :works_too,
+        :after_a,
+        :after_b,
+        :after_c,
+        :inner_after,
+      ])
     end
   end
-end
 
-describe "uniqueness of context tree" do
-  examples = [
-    ::Spec2::Context.contexts[0].contexts[0].examples[0],
-    ::Spec2::Context.contexts[0].contexts[1].contexts[0].examples[0],
-  ]
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "something with after after failure" do
+    H.evt << :root
 
-  it "distinguishes contexts with same what, but different parents" do
-    examples.map &.run
-    evt.should H.eq([
-      :root,
-      :context_a,
-      :works,
-      :inner_context_a,
-      :works_too,
-    ])
+    after { H.evt << :it_is_cleaning_time }
+
+    it "fails" do
+      H.evt << :before_failure
+      raise "I fail"
+    end
+  end
+
+  describe "after block when example failed" do
+    example = ::Spec2::Context.contexts[0].examples[0]
+
+    it "still gets executed" do
+      expect_raises do
+        example.run
+      end
+
+      H.evt.should eq([
+        :root,
+        :before_failure,
+        :it_is_cleaning_time
+      ])
+    end
+  end
+
+  Spec2::Context.__clear
+  evt = empty_evt
+  Spec2::DSL.describe "uniqueness of context tree" do
+    evt << :root
+
+    context "context a" do
+      before { H.evt << :context_a }
+
+      it "works" do
+        H.evt << :works
+      end
+    end
+
+    context "inner" do
+      context "context a" do
+        before { H.evt << :inner_context_a }
+
+        it "works too" do
+          H.evt << :works_too
+        end
+      end
+
+      context "random context inside" do
+      end
+    end
+  end
+
+  describe "uniqueness of context tree" do
+    examples = [
+      ::Spec2::Context.contexts[0].contexts[0].examples[0],
+      ::Spec2::Context.contexts[0].contexts[1].contexts[0].examples[0],
+    ]
+
+    it "distinguishes contexts with same what, but different parents" do
+      examples.map &.run
+      evt.should H.eq([
+        :root,
+        :context_a,
+        :works,
+        :inner_context_a,
+        :works_too,
+      ])
+    end
   end
 end


### PR DESCRIPTION
This PR adds instance/class variable type annotations, so that they don't have to be inferred.

Code still works with both current `HEAD` and `0.15.0`.
