### PR TITLE
Make it work in Crystal 0.20.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: spec2
-version: 0.9.0
+version: 0.9.1
 license: MIT
 
 authors:

--- a/src/matcher.cr
+++ b/src/matcher.cr
@@ -8,7 +8,7 @@ module Spec2
 
   macro register_matcher(name, &block)
     module ::Spec2::Matchers
-      def {{name.id}}({{block.args.argify}})
+      def {{name.id}}({{block.args.splat}})
         {{block.body}}
       end
     end

--- a/src/matchers/be.cr
+++ b/src/matchers/be.cr
@@ -36,7 +36,7 @@ module Spec2
 
       #macro method_missing(name, args, block)
       macro method_missing(call)
-        ok = !!(@actual.{{call.name.id}}({{call.args.argify}}) {{call.block}})
+        ok = !!(@actual.{{call.name.id}}({{call.args.splat}}) {{call.block}})
 
         {% if call.args.size == 0 %}
              failure = "Expected #{@actual.inspect} to be {{call.name.id}}"
@@ -49,8 +49,8 @@ module Spec2
         {% end %}
 
         {% if call.args.size > 1 %}
-             failure = "Expected #{@actual.inspect} to be {{call.name.id}} #{ { {{call.args.argify}} } }"
-             negated = "Expected #{@actual.inspect} not to be {{call.name.id}} #{ { {{call.args.argify}} } }"
+             failure = "Expected #{@actual.inspect} to be {{call.name.id}} #{ { {{call.args.splat}} } }"
+             negated = "Expected #{@actual.inspect} not to be {{call.name.id}} #{ { {{call.args.splat}} } }"
         {% end %}
 
         @expectation.callback(ok, failure, negated)


### PR DESCRIPTION
In Crystal 0.20.1, `argify` has been renamed to `splat`.