### PR TITLE
Update matcher.cr

### DIFF
--- a/src/matcher.cr
+++ b/src/matcher.cr
@@ -8,7 +8,7 @@ module Spec2
 
   macro register_matcher(name, &block)
     module ::Spec2::Matchers
-      def {{name.id}}({{block.args.argify}})
+      def {{name.id}}({{block.args.splat}})
         {{block.body}}
       end
     end


### PR DESCRIPTION
macro method `argify` was renamed to `splat`  [source](https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md#0201-05-12-2016)

closes #48 