### PR TITLE
Change to method to pass a testing

### DIFF
--- a/src/expectation.cr
+++ b/src/expectation.cr
@@ -16,7 +16,7 @@ module Spec2
 
     def to(@matcher)
       return if matcher.match(actual)
-      raise ExpectationNotMet.new(matcher.failure_message)
+      ExpectationNotMet.new(matcher.failure_message)
     end
 
     def to_be


### PR DESCRIPTION
I removed the raise keyword to pass the be_close(expected, delta) testing when in delta-proximity.
Crystal : v0.23.1