### PR TITLE
Fix for crystal version 0.24.1

### DIFF
--- a/spec/elapsed_time_spec.cr
+++ b/spec/elapsed_time_spec.cr
@@ -22,11 +22,11 @@ module Spec2
         end
 
         def to_milliseconds(ms)
-          if Crystal::VERSION =~ /\A0\.(2[0-3]|[01][0-9])\./ # < 0.24
+          {% if Crystal::VERSION =~ /\A0\.(2[0-3]|[01][0-9])\./ %} # < 0.24
             Time::Span.new(ms * 10_000)
-          else
+          {% else %}
             ms.milliseconds
-          end
+          {% end %}
         end
 
         it "returns in milliseconds rounded to .2" do

--- a/spec/elapsed_time_spec.cr
+++ b/spec/elapsed_time_spec.cr
@@ -3,7 +3,7 @@ require "../src/elapsed_time"
 
 module Spec2
   Spec2.describe ElapsedTime do
-    let(started_at) { Time.new(2014, 4, 21, 13, 27, 33, 57) }
+    let(started_at) { Time.new(2014, 4, 21, 13, 27, 33, nanosecond: 57_000_000) }
 
     describe "#to_s" do
       context "when seconds < 1" do
@@ -24,22 +24,22 @@ module Spec2
         it "returns in milliseconds rounded to .2" do
           expect(ElapsedTime.new(
             started_at,
-            started_at + Time::Span.new(36 * 10000)
+            started_at + 36.milliseconds
           ).to_s).to eq("36.0 milliseconds")
 
           expect(ElapsedTime.new(
             started_at,
-            started_at + Time::Span.new(36.5 * 10000)
+            started_at + 36.5.milliseconds
           ).to_s).to eq("36.5 milliseconds")
 
           expect(ElapsedTime.new(
             started_at,
-            started_at + Time::Span.new(36.57 * 10000)
+            started_at + 36.57.milliseconds
           ).to_s).to eq("36.57 milliseconds")
 
           expect(ElapsedTime.new(
             started_at,
-            started_at + Time::Span.new(36.573 * 10000)
+            started_at + 36.573.milliseconds
           ).to_s).to eq("36.57 milliseconds")
         end
       end

--- a/spec/elapsed_time_spec.cr
+++ b/spec/elapsed_time_spec.cr
@@ -3,7 +3,7 @@ require "../src/elapsed_time"
 
 module Spec2
   Spec2.describe ElapsedTime do
-    let(started_at) { Time.new(2014, 4, 21, 13, 27, 33, nanosecond: 57_000_000) }
+    let(started_at) { Time.new(2014, 4, 21, 13, 27, 33) + 57.milliseconds }
 
     describe "#to_s" do
       context "when seconds < 1" do
@@ -21,25 +21,33 @@ module Spec2
           ).to_s).to eq("999.0 milliseconds")
         end
 
+        def to_milliseconds(ms)
+          if Crystal::VERSION =~ /\A0\.(2[0-3]|[01][0-9])\./ # < 0.24
+            Time::Span.new(ms * 10_000)
+          else
+            ms.milliseconds
+          end
+        end
+
         it "returns in milliseconds rounded to .2" do
           expect(ElapsedTime.new(
             started_at,
-            started_at + 36.milliseconds
+            started_at + to_milliseconds(36)
           ).to_s).to eq("36.0 milliseconds")
 
           expect(ElapsedTime.new(
             started_at,
-            started_at + 36.5.milliseconds
+            started_at + to_milliseconds(36.5)
           ).to_s).to eq("36.5 milliseconds")
 
           expect(ElapsedTime.new(
             started_at,
-            started_at + 36.57.milliseconds
+            started_at + to_milliseconds(36.57)
           ).to_s).to eq("36.57 milliseconds")
 
           expect(ElapsedTime.new(
             started_at,
-            started_at + 36.573.milliseconds
+            started_at + to_milliseconds(36.573)
           ).to_s).to eq("36.57 milliseconds")
         end
       end

--- a/spec/matchers_spec.cr
+++ b/spec/matchers_spec.cr
@@ -339,7 +339,7 @@ Spec2.describe Spec2::Matchers do
           expect(42.05).to be_close(42, 0.01)
         }.to raise_error(
           Spec2::ExpectationNotMet,
-          "Expected to be close:\n        Expected:  42\n        Actual:    42.05\n        Max-delta: 0.01\n        Delta:     0.04999999999999716"
+          match(/Expected to be close:\n        Expected:  42\n        Actual:    42.05\n        Max-delta: 0.01\n        Delta:     0.049999999999997\d+/)
         )
       end
     end
@@ -522,14 +522,14 @@ Spec2.describe Spec2::Matchers do
     end
   end
 
-  describe (2 + 2) do
+  describe 2 + 2 do
     context "when describe uses literal expression" do
       it "fails" do
         expect {
           expect(described_class).to eq(4)
         }.to raise_error(
           Exception,
-          "(2 + 2) is expected to be a Class, not Int32"
+          "2 + 2 is expected to be a Class, not Int32"
         )
       end
     end

--- a/spec/matchers_spec.cr
+++ b/spec/matchers_spec.cr
@@ -529,7 +529,7 @@ Spec2.describe Spec2::Matchers do
           expect(described_class).to eq(4)
         }.to raise_error(
           Exception,
-          "2 + 2 is expected to be a Class, not Int32"
+          "(2 + 2) is expected to be a Class, not Int32"
         )
       end
     end

--- a/spec/matchers_spec.cr
+++ b/spec/matchers_spec.cr
@@ -339,7 +339,7 @@ Spec2.describe Spec2::Matchers do
           expect(42.05).to be_close(42, 0.01)
         }.to raise_error(
           Spec2::ExpectationNotMet,
-          "Expected to be close:\n        Expected:  42\n        Actual:    42.05\n        Max-delta: 0.01\n        Delta:     0.049999999999997158"
+          "Expected to be close:\n        Expected:  42\n        Actual:    42.05\n        Max-delta: 0.01\n        Delta:     0.04999999999999716"
         )
       end
     end

--- a/unit_spec/simple_dsl_spec.cr
+++ b/unit_spec/simple_dsl_spec.cr
@@ -465,7 +465,7 @@ module SimpleDSLSpec
     example = ::Spec2::Context.contexts[0].examples[0]
 
     it "still gets executed" do
-      expect_raises do
+      expect_raises(Exception) do
         example.run
       end
 


### PR DESCRIPTION
With the current version of crystal (0.24.1) the tests fail.

The following changes where made:

## 1. Changed Time constructor
In `spec/elapsed_time_spec.cr` I had to change from `Time.new(year, month, day, hour, minute, second, millisecond)` to `Time.new(year, month, day, hour, minute, second) + 57.milliseconds`. This is due to an API change in the Time constructor, which dropped milliseconds but added nanoseconds. With this change both older versions and the current work the same.

## 2. Changed Time::Span constructor
Similar to 1. the constructor of Time::Span changed to now take nanoseconds as a named parameter.

I've added the `to_milliseconds` method to keep backwards compatibility. I used `ms.milliseconds` because it's simpler. Alternatively you could use `Time::Span.new(nanoseconds: ms * 1_000_000)` (note: 100 times more than in the previous version. Using `ms.milliseconds` in older versions does not break the build, but it ignores any floating points.

If you know a better option to check the crystal version or you don't want backwards compatibility just let me know.

## 3. Rounding

It seems like there have been minor changes to the rounding of numbers. The delta between `42.05` and `42` changed from 0.0499999999999971**58** to 0.0499999999999971**6**.

As a workaround I've added a regex matcher that matches both and is in my opinion close enough for the test.

## 4. String represenations of literal expressions

The expression `(2 + 2)` is no as a String `"(2 + 2)"` and not `"2 + 2"` as before. `2 + 2` on the other hand is in all versions `2 + 2` 

As a workaround I've swiched from `(2 + 2)` to `2 + 2`.

## 5. expect_raises without arguments

The methods `expect_raises` without any arguments got removed. I've added the parameter `Exception` to the unit test.

## Testing

I've tested it with docker containers:

```bash
VERSION=0.24.1; docker run --rm -it -v $(pwd):/opt/project crystallang/crystal:$VERSION bash -c "cd /opt/project && crystal deps && ./scripts/test"
VERSION=0.23.1; docker run --rm -it -v $(pwd):/opt/project crystallang/crystal:$VERSION bash -c "cd /opt/project && crystal deps && ./scripts/test"
VERSION=0.22.0; docker run --rm -it -v $(pwd):/opt/project crystallang/crystal:$VERSION bash -c "cd /opt/project && crystal deps && ./scripts/test"
VERSION=0.21.1; docker run --rm -it -v $(pwd):/opt/project crystallang/crystal:$VERSION bash -c "cd /opt/project && crystal deps && ./scripts/test"
VERSION=0.20.1; docker run --rm -it -v $(pwd):/opt/project crystallang/crystal:$VERSION bash -c "cd /opt/project && crystal deps && ./scripts/test"
```